### PR TITLE
fix(codeflow): `.env` is NOT in `.gitignore` (only `.env.local`/`.env*.local` are), allowing li

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,11 @@ artifacts
 *.log
 *.tsbuildinfo
 .env
+.env.*
 .env.local
 .env.*.local
 .env*.local
+!.env.example
 # CodeRag index files
 .coderag-*
 .coderag/


### PR DESCRIPTION
Priority: HIGH
Location: .gitignore

Issue: `.env` is NOT in `.gitignore` (only `.env.local`/`.env*.local` are), allowing live secrets to be committed

Source: DevPulse audit run audit_1780457173


---
Automated by DevPulse dispatcher.